### PR TITLE
change .gitmodules to reference cartpole-java via HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
+
 [submodule "Java/samples/cartpole-java"]
 	path = Java/samples/cartpole-java
-	url = git@github.com:BonsaiAI/cartpole-java.git
+	url = https://github.com/microsoft/cartpole-java.git


### PR DESCRIPTION
Fixes #21 by changing submodule from SSH to HTTPS URL.

This solves the issue, at least in my case. However, I'm not confident about the nuances of submodules and the HTTPS vs SSH protocol. There might be a reason why SSH needs to be used. I *think* HTTPS is better because both repositories are public so there isn't a need for private access keys. HTTPS is the default option that GitHub pops up when you click the Code button to clone a repository, so I suspect it is what most users will try to use.

For more information, this [page](https://memto.github.io/linux/tooltips/2018/05/08/git-submodule-permission-denied-publickey/) suggested the solution. This [page](https://docs.github.com/en/free-pro-team@latest/github/using-git/which-remote-url-should-i-use) describes the two different URL options.

An alternative fix would be to remove the [cartpole-java](https://github.com/microsoft/cartpole-java) repository and directly include it inside microsoft-bonsai-api. Or we could keep a separate repository and, in microsoft-bonsaiapi, provide a readme file with a link telling users about the other repository without including it as a submodule. Submodules can be a confusing feature to use in Git, so perhaps it is better to avoid it if we can.

Thoughts?