### PR TITLE
Journeyman/print unregister details

### DIFF
--- a/Python/samples/cartpole/main.py
+++ b/Python/samples/cartpole/main.py
@@ -375,7 +375,7 @@ def main(
                 print("Episode Finishing...")
                 iteration = 0
             elif event.type == "Unregister":
-                print("Simulator Session unregistered by platform, Registering again!")
+                print("Simulator Session unregistered by platform because '{}', Registering again!".format(event.unregister.details))
                 registered_session, sequence_id = CreateSession(
                     registration_info, config_client
                 )

--- a/Python/samples/house-energy/main.py
+++ b/Python/samples/house-energy/main.py
@@ -252,6 +252,7 @@ def main(render: bool = False, config_setup: bool = False):
             elif event.type == "EpisodeFinish":
                 print("Episode Finishing...")
             elif event.type == "Unregister":
+                print("Simulator Session unregistered by platform because '{}', Registering again!".format(event.unregister.details))
                 client.session.delete(
                     workspace_name=config_client.workspace,
                     session_id=registered_session.session_id,

--- a/Python/samples/quanser-qube/main.py
+++ b/Python/samples/quanser-qube/main.py
@@ -117,6 +117,7 @@ def main(render = False):
             elif event.type == 'EpisodeFinish':
                 print('Episode Finishing...')
             elif event.type == 'Unregister':
+                print("Simulator Session unregistered by platform because '{}', Registering again!".format(event.unregister.details))
                 client.session.delete(
                     workspace_name=config_client.workspace, 
                     session_id=registered_session.session_id


### PR DESCRIPTION
Recently discovered the need to print Unregister details out to CLI for debugging. Reasons for Unregister may involve
- WaitForState
- WaitForAction
- Deployment

This can at least inform the user why their sims continue to Unregister 