### PR TITLE
CSharp,Java: Assign to each unmanaged simulator a simulatorClientId

### DIFF
--- a/CSharp/Microsoft.Bonsai.Api/Simulator/Client/Config.cs
+++ b/CSharp/Microsoft.Bonsai.Api/Simulator/Client/Config.cs
@@ -6,6 +6,8 @@
 
 namespace Microsoft.Bonsai.SimulatorApi.Client
 {
+    using System;
+
     /// <summary>
     /// Configuration information needed to connect to the service.
     /// It will automatically read environment variables and set the config. You can use these setting later for calling APIs.
@@ -50,6 +52,12 @@ namespace Microsoft.Bonsai.SimulatorApi.Client
 
             this.Workspace = string.IsNullOrEmpty(workspace) ? this.Workspace : workspace;
             this.AccessKey = string.IsNullOrEmpty(accessKey) ? this.AccessKey : accessKey;
+
+            if (string.IsNullOrEmpty(this.SimulatorContext))
+            {
+                string clientId = Guid.NewGuid().ToString("N");
+                this.SimulatorContext = $"{{ \"simulatorClientId\": \"{clientId}\" }}";
+            }
 
             this.EnableLogging = enableLogging;
         }

--- a/CSharp/Tests/SimulatorApiTests.cs
+++ b/CSharp/Tests/SimulatorApiTests.cs
@@ -25,7 +25,7 @@ namespace BonsaiSDK.Tests
         [Fact]
         public void TestSessionCreateGetAndDelete()
         {
-            SimulatorInterface createBody = new SimulatorInterface(name: "sim");
+            SimulatorInterface createBody = new SimulatorInterface(name: "sim", simulatorContext: this.config.SimulatorContext);
 
             SimulatorSessionResponse createResponse = this.client.Session.CreateAsync(config.Workspace, createBody).Result;
             Assert.NotNull(createResponse);
@@ -41,7 +41,7 @@ namespace BonsaiSDK.Tests
         [Fact]
         public void TestSessionAdvance()
         {
-            SimulatorInterface createBody = new SimulatorInterface(name: "sim");
+            SimulatorInterface createBody = new SimulatorInterface(name: "sim", simulatorContext: this.config.SimulatorContext);
 
             SimulatorSessionResponse createResponse = this.client.Session.CreateAsync(config.Workspace, createBody).Result;
             Assert.NotNull(createResponse);

--- a/Java/com.microsoft.bonsai.api/simulator/client/BonsaiClientConfig.java
+++ b/Java/com.microsoft.bonsai.api/simulator/client/BonsaiClientConfig.java
@@ -1,5 +1,7 @@
 package com.microsoft.bonsai.simulatorapi.client;
 
+import java.util.UUID;
+
 /**
  * Manages configuration for connecting to the Bonsai platform
  */
@@ -59,8 +61,17 @@ public class BonsaiClientConfig {
         if(this.accessKey.isBlank())
             throw new IllegalArgumentException("Must pass an accessKey value ");
         
-        if (System.getenv(SIM_CONTEXT_ENV) != null) {
-			this.simulatorContext = System.getenv(SIM_CONTEXT_ENV);
+        if (System.getenv(SIM_CONTEXT_ENV) == null) {
+            //
+            // If there is no simulator context, then make one with a clientId.
+            // This will allow SimulatorGateway to recognize this simulator if/when
+            // it re-registers.
+            //
+            UUID clientId = UUID.randomUUID();
+            this.simulatorContext = "{ \"simulatorClientId\": \"" + clientId.toString() + "\" }";
+        }
+        else {
+            this.simulatorContext = System.getenv(SIM_CONTEXT_ENV);
         }
         
         if (System.getenv(SERVER_ENV) != null) {


### PR DESCRIPTION
Add to the C# and Java Simulator SDK some support for unmanaged simulators.
When an unmanaged simulator starts running, this PR will select a simulatorClientId for that simulator.
This simulatorClientId is sent to the Bonsai platform with each registration request.
Once this simulator is assigned to a brain, when it re-registers after a timeout or deployment, this simulator will be assigned to the same brain.