### PR TITLE
[python] Bump msal-extensions and msal

### DIFF
--- a/Python/setup.py
+++ b/Python/setup.py
@@ -31,8 +31,8 @@ setup(
     install_requires=[
         "msrest>=0.6.0",
         "azure-core<2.0.0,>=1.2.0",
-        "msal>=1.2.0,<=1.4.3",
-        "msal_extensions>=0.1.3,<=0.2.2",
+        "msal>=1.2.0,<=1.12.0",
+        "msal_extensions>=0.1.3,<=0.3.0",
     ],
     test_suite="pytest",
     tests_require=["pytest>=5.4.2"],


### PR DESCRIPTION
Bump to something recent.  This also relieves old `portalocker` and `PyJWT` deps.