### PR TITLE
Update plastic extrusion

### DIFF
--- a/Python/samples/plastic-extrusion/README.md
+++ b/Python/samples/plastic-extrusion/README.md
@@ -140,7 +140,7 @@ The example curriculum has 3 lessons, each with random values for initial parame
 
 The first lesson trains the brain over a narrow range of initial screw angular speeds (34-37 RPM) and commensurate initial cutter frequencies.
 
-The subsequent lessons widen the range of initial screw angular speeds by a factor of 5.
+The subsequent lessons widen the range of initial screw angular speeds by a factor of 5 and a factor of 3, respectively.
 
 ### Concept Design - Optimize Yield
 
@@ -149,11 +149,15 @@ Parts with the desired length can be produced by a range of screw angular speeds
 The optimize yield concept adds 2 additional goals:
 
 1) *keep the screw angular speed within 30-40 RPM* (the industry-standard rule of thumb for maintaining material quality of rigid PVC extrudate), and
-2) *maximize manufacturing yield*, i.e. the number of "good" parts per iteration, where good is defined as within the given tolerance for product length.
+2) *maximize manufacturing yield*, i.e. the number of "good" parts per iteration, where "good" is defined as being within the given tolerance for product length.
 
 ## Brain Training Results
 
-Training the *Optimize Length* concept at the provided settings takes about an hour, and training the *Optimize Yield* concept takes around 90 minutes.  At this point the first 2 lessons (*RandomizeStartNarrow* and *RandomizeStartMedium*) should have achieved 100% goal satisfaction, and the final lesson (*RandomizeStartWide*) should have achieved near-100% goal satisfaction.
+Training the *Optimize Length* concept at the provided settings takes about an hour, and at this point all 3 lessons (*RandomizeStartNarrow*, *RandomizeStartMedium*, and *RandomizeStartWide*) should have achieved 100% goal satisfaction.
+
+Training the *Optimize Yield* concept also takes about an hour, although the brain will likely report 100% goal satisfaction from the beginning.  This is not the full story, however; switching to the rewards view shows that the brain continues to learn and improve throughout the training session.  It's worth remembering that the yield optimization goal isn't well defined; *any* yield greater than zero satisfies the goal.  Of course, all other things being equal, larger yields are better than smaller ones; this is where the rewards view provides additional insight.
+
+To switch to the rewards view, right-click just above the training progress graph (e.g. where it says "OptimizeLength"), then click "Show rewards" in the pop-up menu.  (Similarly, to switch back to the goal satisfaction view, select "Show goals" in the pop-up menu.)
 
 ## Next Steps
 

--- a/Python/samples/plastic-extrusion/README.md
+++ b/Python/samples/plastic-extrusion/README.md
@@ -36,15 +36,14 @@ Note: installing the Bonsai API, CLI, and supporting packages in a virtual envir
 
 1. Clone the repo to your local machine.
 2. Create a new `.env` file in the root of the repo and add your workspace credentials.  See `template.env` for an example.
-3. Run `python main.py`.
+3. Build a local Docker container with `docker build -t extrusion .`
+4. Run the local Docker container with `docker run --env-file .env extrusion`
 
 You can now create and train a new brain with the Bonsai web interface or the CLI using the locally running simulator.
 
 ### Building the Simulator Image
 
-Local simulations can only run a single simulation instance for brain training.  To scale up the simulation, we will need to package it into a Docker container.
-
-Creating a Bonsai workspace automatically provisions an Azure Container Registry (ACR) instance.
+Unmanaged simulators can only run a single simulation instance for brain training.  To scale up the simulator, we will need to package it into a Docker container on Azure Container Registry (ACR).  (Creating a Bonsai workspace automatically provisions an associated ACR instance.)
 
 ```sh
 az acr login --name $RegistryName

--- a/Python/samples/plastic-extrusion/README.md
+++ b/Python/samples/plastic-extrusion/README.md
@@ -155,6 +155,18 @@ The optimize yield concept adds 2 additional goals:
 
 Training the *Optimize Length* concept at the provided settings takes about an hour, and training the *Optimize Yield* concept takes around 90 minutes.  At this point the first 2 lessons (*RandomizeStartNarrow* and *RandomizeStartMedium*) should have achieved 100% goal satisfaction, and the final lesson (*RandomizeStartWide*) should have achieved near-100% goal satisfaction.
 
+## Next Steps
+
+Try changing the following [curriculum training parameters](https://docs.microsoft.com/en-us/bonsai/inkling/keywords/curriculum#curriculum-training-parameters) from the example `single.ink` Inkling file and see how they affect the speed and performance of the brain training process:
+
+- the training duration in the `within` clause,
+- the `EpisodeIterationLimit`, and
+- the `NoProgressIterationLimit`.
+
+Since the `EpisodeIterationLimit` is set to 200 iterations in the example, using `within` durations greater than 200 iterations will have no effect unless you also increase the `EpisodeIterationLimit`.
+
+Finally, note that setting the `NoProgressIterationLimit` above 250,000 iterations (the default) will increase the overall brain training time.
+
 ## References
 
 See [References](./docs/references.md) for details.

--- a/Python/samples/plastic-extrusion/docs/README.md
+++ b/Python/samples/plastic-extrusion/docs/README.md
@@ -1,9 +1,0 @@
-# A Note on the Equations
-
-Our [mathematical model](./model.md) of the extrusion process has over two dozen equations.
-
-While GitHub can render mathematical equations in Markdown cells in [Jupyter](https://gist.github.com/cyhsutw/d5983d166fb70ff651f027b2aa56ee4e) [notebooks](https://github.com/jupyter/nbformat/blob/master/docs/markup.rst), GitHub has been [curiously](https://github.com/github/markup/issues/274) [reluctant](https://github.com/github/markup/issues/897) to include support for equations in Markdown and [reStructuredText](https://github.com/github/markup/issues/83) documents.
-
-A [few](https://github.com/leegao/readme2tex) [workarounds](https://gist.github.com/a-rodin/fef3f543412d6e1ec5b6cf55bf197d7b) exist, but these methods lack the convenience of native support, and there is no guarantee that they will work long term.
-
-Fortunately, Visual Studio Code has [native support for rendering equations in Markdown documents with KaTeX](https://code.visualstudio.com/updates/v1_58#_math-formula-rendering-in-the-markdown-preview), so we recommend cloning or downloading this repository to your local machine and rendering the equations with VS Code.

--- a/Python/samples/plastic-extrusion/docs/model.md
+++ b/Python/samples/plastic-extrusion/docs/model.md
@@ -1,5 +1,15 @@
 # Details of the Extrusion Model
 
+## A Note on the Equations
+
+Our mathematical model of the extrusion process below has over two dozen equations.
+
+While GitHub can render mathematical equations in Markdown cells in [Jupyter](https://gist.github.com/cyhsutw/d5983d166fb70ff651f027b2aa56ee4e) [notebooks](https://github.com/jupyter/nbformat/blob/master/docs/markup.rst), GitHub has been [curiously](https://github.com/github/markup/issues/274) [reluctant](https://github.com/github/markup/issues/897) to include support for equations in Markdown and [reStructuredText](https://github.com/github/markup/issues/83) documents.
+
+A [few](https://github.com/leegao/readme2tex) [workarounds](https://gist.github.com/a-rodin/fef3f543412d6e1ec5b6cf55bf197d7b) exist, but these methods lack the convenience of native support, and there is no guarantee that they will work long term.
+
+Fortunately, Visual Studio Code has [native support for rendering equations in Markdown documents with KaTeX](https://code.visualstudio.com/updates/v1_58#_math-formula-rendering-in-the-markdown-preview), so we recommend cloning or downloading this repository to your local machine and rendering the equations with VS Code.
+
 ## Glossary
 
 ### Control Actions

--- a/Python/samples/plastic-extrusion/inkling/multi.ink
+++ b/Python/samples/plastic-extrusion/inkling/multi.ink
@@ -74,14 +74,14 @@ simulator ExtrusionSim (Action: SimAction, Config: SimConfig): SimState {
 
 graph (input: SimState): SimAction {
 
-    concept OptimizeLength(input): SimAction {
+    concept ControlLength(input): SimAction {
         curriculum {
 
             source ExtrusionSim
 
             goal (State: SimState) {
 
-                drive LengthWithinTolerance:
+                drive ValidLength:
                     State.product_length
                     in Goal.Range(LengthTarget - LengthTolerance, LengthTarget + LengthTolerance)
                     within 2 * 60
@@ -128,28 +128,28 @@ graph (input: SimState): SimAction {
     }
 
 
-    concept OptimizeYield(input): SimAction {
+    concept ControlYield(input): SimAction {
 
         curriculum {
             source ExtrusionSim
 
             goal (State: SimState) {
 
-                drive LengthWithinTolerance:
+                drive ValidLength:
                     State.product_length
                     in Goal.Range(LengthTarget - LengthTolerance, LengthTarget + LengthTolerance)
                     within 2 * 60
 
                 # keep screw angular speed in the 30-40 RPM range to optimize product quality
                 # <https://www.ptonline.com/articles/extrusion-processing-rigid-pvc-know-your-rheology->
-                maximize StableScrewSpeed:
+                maximize IdealScrewSpeed:
                     State.screw_angular_speed
                     in Goal.Range(
                         (30 / 60) * RadiansPerRevolution,
                         (40 / 60) * RadiansPerRevolution
                     )
 
-                maximize ProductYieldAtQuality:
+                maximize ProductYield:
                     State.yield in Goal.RangeAbove(0)
 
             }
@@ -194,7 +194,7 @@ graph (input: SimState): SimAction {
     }
 
 
-    output concept Selector(input, OptimizeLength, OptimizeYield): SimAction {
+    output concept Selector(input, ControlLength, ControlYield): SimAction {
         programmed function (State: SimState, control_length: SimAction, control_yield: SimAction): SimAction {
 
             # if the product length is not in spec, fix the length

--- a/Python/samples/plastic-extrusion/inkling/multi.ink
+++ b/Python/samples/plastic-extrusion/inkling/multi.ink
@@ -118,8 +118,8 @@ graph (input: SimState): SimAction {
 
             lesson RandomizeStartWide {
                 scenario {
-                    initial_screw_angular_speed: number <(10 * RadiansPerRevolution / 60) .. (110 * RadiansPerRevolution / 60)>,
-                    initial_cutter_frequency: number <0.03 .. 0.54>,
+                    initial_screw_angular_speed: number <(20 * RadiansPerRevolution / 60) .. (80 * RadiansPerRevolution / 60)>,
+                    initial_cutter_frequency: number <0.06 .. 0.40>,
 
                     initial_screw_angular_acceleration: number <-ScrewAccelerationMax .. ScrewAccelerationMax>,
                     initial_cutter_acceleration: number <-CutterAccelerationMax .. CutterAccelerationMax>,                
@@ -184,8 +184,8 @@ graph (input: SimState): SimAction {
 
             lesson RandomizeStartWide {
                 scenario {
-                    initial_screw_angular_speed: number <(10 * RadiansPerRevolution / 60) .. (110 * RadiansPerRevolution / 60)>,
-                    initial_cutter_frequency: number <0.03 .. 0.54>,
+                    initial_screw_angular_speed: number <(20 * RadiansPerRevolution / 60) .. (80 * RadiansPerRevolution / 60)>,
+                    initial_cutter_frequency: number <0.06 .. 0.40>,
 
                     initial_screw_angular_acceleration: number <-ScrewAccelerationMax .. ScrewAccelerationMax>,
                     initial_cutter_acceleration: number <-CutterAccelerationMax .. CutterAccelerationMax>,                

--- a/Python/samples/plastic-extrusion/inkling/multi.ink
+++ b/Python/samples/plastic-extrusion/inkling/multi.ink
@@ -68,7 +68,7 @@ type SimConfig {
 }
 
 
-simulator ExtrusionSimulator (Action: SimAction, Config: SimConfig): SimState {
+simulator ExtrusionSim (Action: SimAction, Config: SimConfig): SimState {
 }
 
 
@@ -77,7 +77,7 @@ graph (input: SimState): SimAction {
     concept OptimizeLength(input): SimAction {
         curriculum {
 
-            source ExtrusionSimulator
+            source ExtrusionSim
 
             goal (State: SimState) {
 
@@ -131,7 +131,7 @@ graph (input: SimState): SimAction {
     concept OptimizeYield(input): SimAction {
 
         curriculum {
-            source ExtrusionSimulator
+            source ExtrusionSim
 
             goal (State: SimState) {
 

--- a/Python/samples/plastic-extrusion/inkling/multi.ink
+++ b/Python/samples/plastic-extrusion/inkling/multi.ink
@@ -137,11 +137,6 @@ graph (input: SimState): SimAction {
 
             goal (State: SimState) {
 
-                drive ValidLength:
-                    State.product_length
-                    in Goal.Range(LengthTarget - LengthTolerance, LengthTarget + LengthTolerance)
-                    within 2 * 60
-
                 # keep screw angular speed in the 30-40 RPM range to optimize product quality
                 # <https://www.ptonline.com/articles/extrusion-processing-rigid-pvc-know-your-rheology->
                 maximize IdealScrewSpeed:
@@ -158,7 +153,7 @@ graph (input: SimState): SimAction {
 
             training {
                 EpisodeIterationLimit: 200,  # default is 1,000
-             }
+            }
 
             lesson RandomizeStartNarrow {
                 scenario {

--- a/Python/samples/plastic-extrusion/inkling/multi.ink
+++ b/Python/samples/plastic-extrusion/inkling/multi.ink
@@ -69,6 +69,8 @@ type SimConfig {
 
 
 simulator ExtrusionSim (Action: SimAction, Config: SimConfig): SimState {
+    # Automatically launch the simulator with this registered package name.
+    package "PVC_Extruder"
 }
 
 

--- a/Python/samples/plastic-extrusion/inkling/single.ink
+++ b/Python/samples/plastic-extrusion/inkling/single.ink
@@ -71,14 +71,14 @@ simulator ExtrusionSim (Action: SimAction, Config: SimConfig): SimState {
 
 graph (input: SimState): SimAction {
 
-    concept OptimizeLength(input): SimAction {
+    concept ControlLength(input): SimAction {
         curriculum {
 
             source ExtrusionSim
 
             goal (State: SimState) {
 
-                drive LengthWithinTolerance:
+                drive ValidLength:
                     State.product_length
                     in Goal.Range(LengthTarget - LengthTolerance, LengthTarget + LengthTolerance)
                     within 2 * 60

--- a/Python/samples/plastic-extrusion/inkling/single.ink
+++ b/Python/samples/plastic-extrusion/inkling/single.ink
@@ -66,6 +66,8 @@ type SimConfig {
 
 
 simulator ExtrusionSim (Action: SimAction, Config: SimConfig): SimState {
+    # Automatically launch the simulator with this registered package name.
+    package "PVC_Extruder"
 }
 
 

--- a/Python/samples/plastic-extrusion/inkling/single.ink
+++ b/Python/samples/plastic-extrusion/inkling/single.ink
@@ -65,7 +65,7 @@ type SimConfig {
 }
 
 
-simulator ExtrusionSimulator (Action: SimAction, Config: SimConfig): SimState {
+simulator ExtrusionSim (Action: SimAction, Config: SimConfig): SimState {
 }
 
 
@@ -74,7 +74,7 @@ graph (input: SimState): SimAction {
     concept OptimizeLength(input): SimAction {
         curriculum {
 
-            source ExtrusionSimulator
+            source ExtrusionSim
 
             goal (State: SimState) {
 

--- a/Python/samples/plastic-extrusion/inkling/single.ink
+++ b/Python/samples/plastic-extrusion/inkling/single.ink
@@ -115,8 +115,8 @@ graph (input: SimState): SimAction {
 
             lesson RandomizeStartWide {
                 scenario {
-                    initial_screw_angular_speed: number <(10 * RadiansPerRevolution / 60) .. (110 * RadiansPerRevolution / 60)>,
-                    initial_cutter_frequency: number <0.03 .. 0.54>,
+                    initial_screw_angular_speed: number <(20 * RadiansPerRevolution / 60) .. (80 * RadiansPerRevolution / 60)>,
+                    initial_cutter_frequency: number <0.06 .. 0.40>,
 
                     initial_screw_angular_acceleration: number <-ScrewAccelerationMax .. ScrewAccelerationMax>,
                     initial_cutter_acceleration: number <-CutterAccelerationMax .. CutterAccelerationMax>,                

--- a/Python/samples/plastic-extrusion/interface.json
+++ b/Python/samples/plastic-extrusion/interface.json
@@ -1,5 +1,5 @@
 {
-    "name": "extrusion_demo",
+    "name": "PVC_Extruder",
     "timeout": 60,
     "description": {
         "config": {


### PR DESCRIPTION
Update the plastic extrusion demo with the following changes:

- Automatically launch the registered simulator if available in Azure Container Repository (ACR)
- Rename brain training concepts and goals for clarity (and to fit in the Bonsai UI elements wherever possible)
- Various documentation enhancements, including ideas for further exploration with the brain training