### PR TITLE
add schedule_index 3 to Python house energy sample

### DIFF
--- a/Python/samples/house-energy/main.py
+++ b/Python/samples/house-energy/main.py
@@ -235,8 +235,8 @@ def test_random_policy(
     """
 
     sim = TemplateSimulatorSession(render=render, log_file="house-energy.csv")
-    for episode in range(num_episodes):
-        iteration = 0
+    for episode in range(1, num_episodes+1):
+        iteration = 1
         terminal = False
         config = {
             "K": 0.5,
@@ -248,7 +248,15 @@ def test_random_policy(
             "timestep": 5,
             "max_iterations": int(1 * 24 * 60 / 5),
         }
-        obs = sim.episode_start(config=config)
+        sim.episode_start(config=config)
+        sim_state = sim.get_state()
+        if log_iterations:
+            action = sim.random_policy()
+            for key, value in action.items():
+                action[key] = None
+            sim.log_iterations(
+                state=sim_state, action=action, episode=episode, iteration=iteration
+            )
         while not terminal:
             action = sim.random_policy()
             sim.episode_step(action)

--- a/Python/samples/house-energy/main.py
+++ b/Python/samples/house-energy/main.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import time
 import datetime
+import random
 from distutils.util import strtobool
 from typing import Any, Dict, List, Union
 
@@ -52,7 +53,7 @@ class TemplateSimulatorSession:
             "C": 0.3,
             "Qhvac": 9,
             "Tin_initial": 30,
-            "schedule_index": 2,
+            "schedule_index": 3,
             "number_of_days": 1,
             "timestep": 5,
             "max_iterations": int(1 * 24 * 60 / 5),
@@ -168,12 +169,13 @@ class TemplateSimulatorSession:
 
         import pandas as pd
 
-        def add_prefixes(d, prefix: str):
-            return {f"{prefix}_{k}": v for k, v in d.items()}
+        # def add_prefixes(d, prefix: str):
+        #     return {f"{prefix}_{k}": v for k, v in d.items()}
 
-        state = add_prefixes(state, "state")
-        action = add_prefixes(action, "action")
-        config = add_prefixes(self.default_config, "config")
+        # state = add_prefixes(state, "state")
+        # action = add_prefixes(action, "action")
+        # config = add_prefixes(self.sim_config, "config")
+        config = self.sim_config
         data = {**state, **action, **config}
         data["episode"] = episode
         data["iteration"] = iteration
@@ -236,7 +238,17 @@ def test_random_policy(
     for episode in range(num_episodes):
         iteration = 0
         terminal = False
-        obs = sim.episode_start()
+        config = {
+            "K": 0.5,
+            "C": 0.3,
+            "Qhvac": 9,
+            "Tin_initial": random.randint(18, 30),
+            "schedule_index": 3,
+            "number_of_days": 1,
+            "timestep": 5,
+            "max_iterations": int(1 * 24 * 60 / 5),
+        }
+        obs = sim.episode_start(config=config)
         while not terminal:
             action = sim.random_policy()
             sim.episode_step(action)
@@ -371,7 +383,7 @@ if __name__ == "__main__":
 
     if args.test_local:
         test_random_policy(
-            render=args.render, num_episodes=1000, log_iterations=args.log_iterations
+            render=args.render, num_episodes=500, log_iterations=args.log_iterations
         )
     else:
         main(config_setup=args.config_setup, render=args.render)

--- a/Python/samples/house-energy/sim/house_simulator.py
+++ b/Python/samples/house-energy/sim/house_simulator.py
@@ -39,6 +39,11 @@ class House():
             self.Tset_schedule[96:204] = 20
             self.Tout_schedule = np.full(self.max_iterations, 32)
             self.occupancy_schedule = np.full(self.max_iterations, 1)
+        # constant
+        if schedule_index == 3:
+            self.Tset_schedule = np.full(self.max_iterations, 25)
+            self.Tout_schedule = np.full(self.max_iterations, 32)
+            self.occupancy_schedule = np.full(self.max_iterations, 1)
 
         self.Tset = self.Tset_schedule[0] # Set Temperature
         self.Tout = self.Tout_schedule[0] # Outside temperature


### PR DESCRIPTION
1) Added schedule_index == 3 to sim/house_simulator.py. This returns a constant Tset and Tout across episodes.
2) Added sim_config to test_random_policy in main.py. Tin_initial is now randomly initialized in the beginning of each episode.