### PR TITLE
Jill/house energy/rm schedule index

### DIFF
--- a/Python/samples/house-energy/README.md
+++ b/Python/samples/house-energy/README.md
@@ -49,17 +49,19 @@ bonsai simulator unmanaged connect -b $brain_name --action Train --concept-name 
 ## Terminal Conditions
 
 - Exceed 288 iterations in an episode
-- Exceed > 10°C of desired temperature
 
 ## Configuration Parameters
 
 - K
 - C
 - Qhvac
-- schedule_index
-- number_of_days
-- timestep
 - Tin_initial
+- Tout_initial
+- Tout_amplitude
+- Tset_temp_start
+- Tset_temp_stop
+- Tset_time_transition
+- timestep
 - max_iterations
 
 ### Initial conditions
@@ -71,7 +73,7 @@ bonsai simulator unmanaged connect -b $brain_name --action Train --concept-name 
 
 ## Simulator API - Python
 
-- `setup_schedule()`
+- `build_schedule()`
 - `update_hvacON()`
 - `update_Tin()`
 - `show()`

--- a/Python/samples/house-energy/machine_teacher.ink
+++ b/Python/samples/house-energy/machine_teacher.ink
@@ -17,14 +17,13 @@ type SimAction {
 }
 
 type SimConfig {
-    K: Number.Float32, # Thermal conductivity
-    C: Number.Float32, # Thermal Capacity
+    K: number, # Thermal conductivity
+    C: number, # Thermal Capacity
     Qhvac: Number.Float32, # Heat Flux
     Tin_initial: number, # C
-    schedule_index: Number.Int8, # 1 - fixed, 2 - randomized
-    number_of_days: number,
-    timestep: number, # Min
-    max_iterations: number, # Alters schedule generation
+    Tout_initial: number, # C, sinewave signal bias
+    Tset_temp_transitions: number[1][2],
+    Tset_time_transitions: number[1][2],
 }
 
 function TempDiff(Tin:number, Tset:number) {
@@ -53,10 +52,10 @@ graph (input: ObservableState): SimAction {
                     C: 0.3,
                     Qhvac: 9,
                     Tin_initial: number<18 .. 30>,
-                    schedule_index: 2,
-                    number_of_days: 1,
-                    timestep: 5,
-                    max_iterations: MaxIterations
+                    Tout_initial: number<18 .. 22>, # C, sinewave signal bias
+                    Tset_temp_transitions: [20, 25],
+                    Tset_time_transitions: [0, 12],
+                }
                 }
             }
         }

--- a/Python/samples/house-energy/machine_teacher.ink
+++ b/Python/samples/house-energy/machine_teacher.ink
@@ -20,10 +20,12 @@ type SimConfig {
     K: number, # Thermal conductivity
     C: number, # Thermal Capacity
     Qhvac: Number.Float32, # Heat Flux
-    Tin_initial: number, # C
-    Tout_initial: number, # C, sinewave signal bias
-    Tset_temp_transitions: number[1][2],
-    Tset_time_transitions: number[1][2],
+    Tin_initial: number, # C, initial indoor temperature
+    Tout_initial: number, # C, outdoor temperature sine wave signal bias
+    Tout_amplitude: number, # C, outdoor temperature sine wave amplitude 
+    Tset_temp_start: number, # C, starting Tset
+    Tset_temp_stop: number, # C, ending Tset
+    Tset_time_transition: number, # time (in hours) to transition from starting Tset to ending Tset
 }
 
 function TempDiff(Tin:number, Tset:number) {
@@ -52,9 +54,11 @@ graph (input: ObservableState): SimAction {
                     C: 0.3,
                     Qhvac: 9,
                     Tin_initial: number<18 .. 30>,
-                    Tout_initial: number<18 .. 22>, # C, sinewave signal bias
-                    Tset_temp_transitions: [20, 25],
-                    Tset_time_transitions: [0, 12],
+                    Tout_initial: number<18 .. 25>, # C,
+                    Tset_temp_start: Number.Int8<20 .. 22>,
+                    Tset_temp_stop: 25,
+                    Tset_time_transition: Number.Int8<8 .. 12>,
+
                 }
                 }
             }

--- a/Python/samples/house-energy/main.py
+++ b/Python/samples/house-energy/main.py
@@ -53,8 +53,9 @@ class TemplateSimulatorSession:
             "C": 0.3,
             "Qhvac": 9,
             "Tin_initial": 30,
-            "schedule_index": 3,
-            "number_of_days": 1,
+            "Tout_initial": 20,
+            "Tset_temp_transitions": [20, 25],
+            "Tset_time_transitions": [0, 12],
             "timestep": 5,
             "max_iterations": int(1 * 24 * 60 / 5),
         }
@@ -80,9 +81,6 @@ class TemplateSimulatorSession:
 
         sim_state = {
             "Tset": float(self.simulator.Tset),
-            "Tset1": float(self.simulator.Tset1),  # forecast at +1 iteration
-            "Tset2": float(self.simulator.Tset2),  # forecast at +2 iterations
-            "Tset3": float(self.simulator.Tset3),  # forecast at +3 iterations
             "Tin": float(self.simulator.Tin),
             "Tout": float(self.simulator.Tout),
             "power": float(self.simulator.get_Power()),
@@ -109,13 +107,11 @@ class TemplateSimulatorSession:
             C=self.sim_config["C"],
             Qhvac=self.sim_config["Qhvac"],
             Tin_initial=self.sim_config["Tin_initial"],
+            Tout_initial=self.sim_config["Tout_initial"],
+            Tset_temp_transitions=self.sim_config["Tset_temp_transitions"],
+            Tset_time_transitions=self.sim_config["Tset_time_transitions"],
         )
-        self.simulator.setup_schedule(
-            days=self.sim_config["number_of_days"],
-            timestep=self.sim_config["timestep"],
-            schedule_index=self.sim_config["schedule_index"],
-            max_iterations=288,
-        )
+        self.simulator.build_schedule()
 
     def episode_start(self, config: Dict[str, Any] = None):
         """Method invoked at the start of each episode with a given 
@@ -243,8 +239,9 @@ def test_random_policy(
             "C": 0.3,
             "Qhvac": 9,
             "Tin_initial": random.randint(18, 30),
-            "schedule_index": 3,
-            "number_of_days": 1,
+            "Tout_initial": 20,
+            "Tset_temp_transitions": [20, 25],
+            "Tset_time_transitions": [0, 12],
             "timestep": 5,
             "max_iterations": int(1 * 24 * 60 / 5),
         }

--- a/Python/samples/house-energy/main.py
+++ b/Python/samples/house-energy/main.py
@@ -54,8 +54,10 @@ class TemplateSimulatorSession:
             "Qhvac": 9,
             "Tin_initial": 30,
             "Tout_initial": 20,
-            "Tset_temp_transitions": [20, 25],
-            "Tset_time_transitions": [0, 12],
+            "Tout_amplitude": 5,
+            "Tset_temp_start": 25,
+            "Tset_temp_stop": 20,
+            "Tset_time_transition": 8,
             "timestep": 5,
             "max_iterations": int(1 * 24 * 60 / 5),
         }
@@ -108,8 +110,10 @@ class TemplateSimulatorSession:
             Qhvac=self.sim_config["Qhvac"],
             Tin_initial=self.sim_config["Tin_initial"],
             Tout_initial=self.sim_config["Tout_initial"],
-            Tset_temp_transitions=self.sim_config["Tset_temp_transitions"],
-            Tset_time_transitions=self.sim_config["Tset_time_transitions"],
+            Tout_amplitude=self.sim_config["Tout_amplitude"],
+            Tset_temp_start=self.sim_config["Tset_temp_start"],
+            Tset_temp_stop=self.sim_config["Tset_temp_stop"],
+            Tset_time_transition=self.sim_config["Tset_time_transition"],
         )
         self.simulator.build_schedule()
 
@@ -167,7 +171,7 @@ class TemplateSimulatorSession:
 
         # def add_prefixes(d, prefix: str):
         #     return {f"{prefix}_{k}": v for k, v in d.items()}
-
+        
         # state = add_prefixes(state, "state")
         # action = add_prefixes(action, "action")
         # config = add_prefixes(self.sim_config, "config")
@@ -238,10 +242,12 @@ def test_random_policy(
             "K": 0.5,
             "C": 0.3,
             "Qhvac": 9,
-            "Tin_initial": random.randint(18, 30),
-            "Tout_initial": 20,
-            "Tset_temp_transitions": [20, 25],
-            "Tset_time_transitions": [0, 12],
+            "Tin_initial": random.uniform(18, 30),
+            "Tout_initial": random.uniform(18, 25),
+            "Tout_amplitude": random.uniform(3, 5),
+            "Tset_temp_start": random.randint(20, 22),
+            "Tset_temp_stop": 25,
+            "Tset_time_transition": random.randint(8, 12),
             "timestep": 5,
             "max_iterations": int(1 * 24 * 60 / 5),
         }

--- a/Python/samples/house-energy/sim/house_simulator.py
+++ b/Python/samples/house-energy/sim/house_simulator.py
@@ -2,7 +2,19 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 class House():
-    def __init__(self, K: float=0.5, C: float=0.3, Qhvac: float=9, hvacON: float=0, occupancy: float=1, Tin_initial: float=30):
+    def __init__(self, 
+                K: float=0.5, 
+                C: float=0.3, 
+                Qhvac: float=9, 
+                hvacON: float=0, 
+                occupancy: float=1, 
+                Tin_initial: float=30, 
+                Tout_initial: float= 20,
+                Tset_temp_transitions: float = [20, 25],
+                Tset_time_transitions: float = [0, 12],
+                timestep: float=5, 
+                max_iterations: float=288,):
+
         self.K = K # thermal conductivity
         self.C = C # thermal capacity
         self.Tin = Tin_initial # Inside Temperature 
@@ -12,50 +24,39 @@ class House():
         self.occupancy = occupancy # 0 (no one in the room) or 1 (somebody in the room)
         self.Phvac = Qhvac # Electric power capacity 
 
+        self.timestep = timestep # minutes
+        self.Tout_initial = Tout_initial # sinewave signal bias for outside temperature flucation
+        self.Tset_temp_transitions = Tset_temp_transitions # ordered array of temperature set points
+        self.Tset_time_transitions = Tset_time_transitions # ordered array of timestamps for temp transitions
+        self.max_iterations = max_iterations #10 more steps incase we need to use forecast
+        self.build_schedule()
+
         plt.close()
         self.fig, self.ax = plt.subplots(1, 1)
 
-    def setup_schedule(self, days: int=1, timestep: int=5, schedule_index: int=2, max_iterations: int=288):
+    def build_schedule(self):
         """ define the Tset_schedule, Tout_schedule, the length of schedule, timestep
         """
-        self.timestep = timestep # keep in minutes here to keep number of minutes for days consistent
-        self.max_iterations = max_iterations #10 more steps incase we need to use forecast
-
-        # randomize
-        if schedule_index == 1:
-            self.Tset_schedule = np.full(self.max_iterations, 25)
-            self.Tout_schedule = np.full(self.max_iterations, 32)
-            self.occupancy_schedule = np.full(self.max_iterations, 1)
-            for d in range(days):
-                a = time_to_index(d, 9)
-                b = time_to_index(d, 17)
-                self.Tset_schedule[a:b]= np.random.randint(low=18, high=25)
-                c = time_to_index(d, 0)
-                d = time_to_index(d, 24)
-                self.Tout_schedule[c:d] = np.random.randint(low=28, high=35)
-        # simpler
-        if schedule_index == 2:
-            self.Tset_schedule = np.full(self.max_iterations, 25)
-            self.Tset_schedule[96:204] = 20
-            self.Tout_schedule = np.full(self.max_iterations, 32)
-            self.occupancy_schedule = np.full(self.max_iterations, 1)
-        # constant
-        if schedule_index == 3:
-            self.Tset_schedule = np.full(self.max_iterations, 25)
-            self.Tout_schedule = np.full(self.max_iterations, 32)
-            self.occupancy_schedule = np.full(self.max_iterations, 1)
+        time = np.arange(self.max_iterations)
+        Tset_time_transitions_idx = [time_to_index(0, t) for t in self.Tset_time_transitions]
+        print(Tset_time_transitions_idx)
+        print(self.Tset_temp_transitions)
+        self.Tset_schedule = np.piecewise(
+                time,
+                [(time >= Tset_time_transitions_idx[i]) & (time <= Tset_time_transitions_idx[i+1]) for i in range(len(Tset_time_transitions_idx)-1)],
+                self.Tset_temp_transitions)
+        
+        self.Tout_schedule = 5*np.sin(np.linspace(0, 2*np.pi, self.max_iterations + 1)) + self.Tout_initial
+        self.occupancy_schedule = np.full(self.max_iterations, 1)
 
         self.Tset = self.Tset_schedule[0] # Set Temperature
         self.Tout = self.Tout_schedule[0] # Outside temperature
-
-        self.Tset1 = self.Tset_schedule[1] # Set Temperature i+1
-        self.Tset2 = self.Tset_schedule[2] # Set Temperature i+2
-        self.Tset3 = self.Tset_schedule[3] # Set Temperature i+3
 
         # For plotting only
         self.time_to_plot = [0]
         self.Tin_to_plot = [self.Tin]
         self.Tset_to_plot = [self.Tset]
+        self.Tout_to_plot = [self.Tout]
 
         self.__iter__()
 
@@ -81,6 +82,7 @@ class House():
         self.__next__()
         self.Tset_to_plot.append(self.Tset)
         self.Tin_to_plot.append(self.Tin)
+        self.Tout_to_plot.append(self.Tout)
         self.time_to_plot.append(self.iteration * 5)
 
     def get_Power(self):
@@ -93,6 +95,7 @@ class House():
         self.ax.clear()
         self.ax.plot(self.time_to_plot, self.Tin_to_plot, label='Tin')
         self.ax.plot(self.time_to_plot, self.Tset_to_plot, label='Tset')
+        self.ax.plot(self.time_to_plot, self.Tout_to_plot, label='Tout')
         self.ax.set_xlabel('Time [min]')
         self.ax.set_ylabel(r'Temperature [$^\circ$C]')
         plt.legend()
@@ -116,9 +119,6 @@ class House():
         if self.iteration <= self.max_iterations - 5:
             self.iteration += 1
             self.update_Tset(self.Tset_schedule[self.iteration])
-            self.Tset1 = self.Tset_schedule[self.iteration+1]
-            self.Tset2 = self.Tset_schedule[self.iteration+2]
-            self.Tset3 = self.Tset_schedule[self.iteration+3]
             self.update_Tout(self.Tout_schedule[self.iteration])
             self.update_occupancy(self.occupancy_schedule[self.iteration])
         else:
@@ -135,13 +135,10 @@ if __name__ == '__main__':
     house = House()
     
     for episode in range(2):
-        house.setup_schedule(days=1,
-                             timestep=5,
-                             schedule_index=2,
-                             max_iterations= 288)
+        house.build_schedule()
         for i in range(288):
             house.update_hvacON(random.randint(0, 1))
             house.update_Tin()
-            print('Tin : {}'.format(house.Tin))
+            # print('Tin : {}'.format(house.Tin))
             house.show()
 


### PR DESCRIPTION
Remove schedule_index to expose Tset and Tout parameters to the simulator configuration in Bonsai. Tset and Tout schedules are built similar to "signal_builder" in the DDM repo.

- [x] Log data
- [x] Run local unmanaged
- [ ] Scale and train a brain