### PR TITLE
Forgetting memory for exported brain

### DIFF
--- a/Python/samples/quanser-qube/main.py
+++ b/Python/samples/quanser-qube/main.py
@@ -33,7 +33,7 @@ from microsoft_bonsai_api.simulator.generated.models import (
 from azure.core.exceptions import HttpResponseError
 import argparse
 from sim.qube_simulator import QubeSimulator
-from policies import random_policy, brain_policy
+from policies import random_policy, brain_policy, forget_memory
 
 LOG_PATH = "logs"
 
@@ -204,6 +204,12 @@ def test_policy(
         terminal = False
         sim_state = sim.episode_start(config=scenario_configs[episode-1])
         sim_state = sim.get_state()
+
+        if any('exported_brain_url' in key for key in policy.keywords):
+            # Reset the Memory vector because exported brains don't understand episodes 
+            url = '{}/v1'.format(policy.keywords['exported_brain_url'])
+            forget_memory(url)
+
         if log_iterations:
             action = policy(sim_state)
             for key, value in action.items():

--- a/Python/samples/quanser-qube/policies.py
+++ b/Python/samples/quanser-qube/policies.py
@@ -7,7 +7,6 @@ import random
 from typing import Dict
 import requests
 
-
 def random_policy(state):
     """
     Ignore the state, move randomly.
@@ -24,3 +23,13 @@ def brain_policy(
     response = requests.get(prediction_endpoint, json=state)
 
     return response.json()
+
+def forget_memory(
+    url: str = "http://localhost:5000/v1"
+):
+    # Reset the Memory vector because exported brains don't understand episodes 
+    response = requests.delete(url)
+    if response.status_code == 204:
+        print('Resetting Memory vector in exported brain...')
+    else:
+       print('Error: {}'.format(response.status_code)) 


### PR DESCRIPTION
Exported brains have no concept of episodes. memory is default. This is an approach to resetting memory when a user does `--test-exported` . 