### PR TITLE
add Python environment folder names to gitignore

### DIFF
--- a/Python/.gitignore
+++ b/Python/.gitignore
@@ -1,5 +1,16 @@
-# Distribution / packaging
-*.egg-info
-build/
+# Byte-compiled / optimized / DLL files
 __pycache__/
+
+# Distribution / packaging
+build/
 dist/
+*.egg-info/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
By default when I open up one of our samples in Visual Studio offers to create an env folder and set up a virtual envrionment for the project. This is nice, but I don't want to accidentally check it in.

It looks like the .gitignore for Python in microsoft-bonsa-api is intended to be a subset of https://github.com/github/gitignore/blob/master/Python.gitignore. To that end, I have:
1. Reorganized the .gitignore file to exacly match the order and text of lines inside Python.gitignore.
2. Added the # Environments section because I think it will be helpful to people to ignore environments using these directory name conventions that are created within our samples.these directory naming