### PR TITLE
use slim version of the Python container in simple-adder sample

### DIFF
--- a/Python/samples/simple-adder/Dockerfile
+++ b/Python/samples/simple-adder/Dockerfile
@@ -1,5 +1,5 @@
 # this is one of the cached base images available for ACI
-FROM python:3.7.4
+FROM python:3.7.4-slim
 
 # Set up the simulator
 WORKDIR /src

--- a/Python/samples/simple-adder/Dockerfile
+++ b/Python/samples/simple-adder/Dockerfile
@@ -1,4 +1,5 @@
-# this is one of the cached base images available for ACI
+# Base this container on the Python slim container image available from ACI.
+# See Image Variants at https://hub.docker.com/_/python for information about different flavors of Python containers.
 FROM python:3.7.4-slim
 
 # Set up the simulator


### PR DESCRIPTION
Reduces docker image size from 1GB to 300 MB.