### PR TITLE
Make tests independent of local environment and use pytest built-in to check for correct exception

### DIFF
--- a/Python/tests/test_client.py
+++ b/Python/tests/test_client.py
@@ -3,12 +3,14 @@ Tests for BonsaiClient class
 Copyright 2020 Microsoft
 """
 from unittest.mock import Mock, patch
-from microsoft_bonsai_api.simulator.client import BonsaiClientConfig, BonsaiClient
-from microsoft_bonsai_api.simulator.generated.models import (
-    SimulatorInterface,
-    SimulatorState,
-)
+
+import pytest
 from azure.core.exceptions import HttpResponseError
+
+from microsoft_bonsai_api.simulator.client import (BonsaiClient,
+                                                   BonsaiClientConfig)
+from microsoft_bonsai_api.simulator.generated.models import (
+    SimulatorInterface, SimulatorState)
 
 
 def test_default_client_construction():
@@ -21,21 +23,16 @@ def test_default_client_construction():
 def test_no_access_key_throws_error():
     config = BonsaiClientConfig()
     config.workspace = "1"
-    try:
+
+    with pytest.raises(RuntimeError):
         BonsaiClient(config)
-        assert False
-    except RuntimeError:
-        pass
 
 
 def test_no_workspace_throws_error():
     config = BonsaiClientConfig()
     config.access_key = "1"
-    try:
+    with pytest.raises(RuntimeError):
         BonsaiClient(config)
-        assert False
-    except RuntimeError:
-        pass
 
 
 def test_400_err_registration():

--- a/Python/tests/test_client.py
+++ b/Python/tests/test_client.py
@@ -21,18 +21,20 @@ def test_default_client_construction():
 
 
 def test_no_access_key_throws_error():
-    config = BonsaiClientConfig()
-    config.workspace = "1"
+    with patch.dict("os.environ", {}, clear=True):
+        config = BonsaiClientConfig()
+        config.workspace = "1"
 
-    with pytest.raises(RuntimeError):
-        BonsaiClient(config)
+        with pytest.raises(RuntimeError):
+            BonsaiClient(config)
 
 
 def test_no_workspace_throws_error():
-    config = BonsaiClientConfig()
-    config.access_key = "1"
-    with pytest.raises(RuntimeError):
-        BonsaiClient(config)
+    with patch.dict("os.environ", {}, clear=True):
+        config = BonsaiClientConfig()
+        config.access_key = "1"
+        with pytest.raises(RuntimeError):
+            BonsaiClient(config)
 
 
 def test_400_err_registration():

--- a/Python/tests/test_config.py
+++ b/Python/tests/test_config.py
@@ -9,9 +9,10 @@ from microsoft_bonsai_api.simulator.client import BonsaiClientConfig
 
 
 def test_default_config():
-    config = BonsaiClientConfig()
-    assert config.workspace == ""
-    assert config.server == "https://api.bons.ai"
+    with patch.dict("os.environ", {}, clear=True):
+        config = BonsaiClientConfig()
+        assert config.workspace == ""
+        assert config.server == "https://api.bons.ai"
 
 
 def test_config_reads_env_vars():

--- a/Python/tests/test_config.py
+++ b/Python/tests/test_config.py
@@ -3,8 +3,9 @@ Tests for Config class
 Copyright 2020 Microsoft
 """
 
-from microsoft_bonsai_api.simulator.client import BonsaiClientConfig
 from unittest.mock import patch
+
+from microsoft_bonsai_api.simulator.client import BonsaiClientConfig
 
 
 def test_default_config():


### PR DESCRIPTION
This PR changes two things:

1. It introduces `pytest.raises` in order to test that the proper exception is raised when some conditions are met
2. It introduces an env variables clean-up before running tests that expect empty access key and empty configuration

The motivation for the second point is that tests fail when some environment variables are set (for example `SIM_ACCESS_KEY` or `SIM_WORKSPACE`). Reason is that the API connector fetches these config parameters from the env and tests do not expect that.