### PR TITLE
Fix imports in house energy sample

### DIFF
--- a/Python/samples/house-energy/main.py
+++ b/Python/samples/house-energy/main.py
@@ -3,23 +3,22 @@
 Microsoft-Bonsai-API integration with House Energy Simulator
 """
 
+import datetime
+import json
 import os
 import pathlib
 import time
-import datetime
-import random
-from distutils.util import strtobool
-from typing import Any, Dict, List, Union
+from functools import partial
+from typing import Any, Dict, Union
+
 from azure.core.exceptions import HttpResponseError
 from dotenv import load_dotenv, set_key
-import json
-from microsoft_bonsai_api.simulator.client import BonsaiClient, BonsaiClientConfig
+from microsoft_bonsai_api.simulator.client import (BonsaiClient,
+                                                   BonsaiClientConfig)
 from microsoft_bonsai_api.simulator.generated.models import (
-    SimulatorInterface,
-    SimulatorState,
-)
+    SimulatorInterface, SimulatorState)
 
-from policies import random_policy, forget_memory, brain_policy
+from policies import brain_policy, forget_memory, random_policy
 from sim import house_simulator
 
 LOG_PATH = "logs"
@@ -180,7 +179,6 @@ class TemplateSimulatorSession:
 
         # def add_prefixes(d, prefix: str):
         #     return {f"{prefix}_{k}": v for k, v in d.items()}
-        
         # state = add_prefixes(state, "state")
         # action = add_prefixes(action, "action")
         # config = add_prefixes(self.sim_config, "config")

--- a/Python/samples/house-energy/policies.py
+++ b/Python/samples/house-energy/policies.py
@@ -6,6 +6,8 @@ Brain states and return Brain actions.
 import random
 from typing import Dict
 
+import requests
+
 
 def random_policy(state: Dict = None):
     """

--- a/Python/samples/house-energy/requirements.txt
+++ b/Python/samples/house-energy/requirements.txt
@@ -3,4 +3,4 @@ numpy>=1.15.1
 python-dotenv==0.13.0
 bonsai-cli==1.0.0
 microsoft-bonsai-api==0.1.1
-matplotlib==3.0.3
+matplotlib


### PR DESCRIPTION
There were missing imports in the sample such as functools.partial in main.py
and requests in policies.py.
In addition, I had difficulties installing the pinned version of matplotlib
so I figured to unpin. I think the version shouldn't be too critical for
running the sample.

PS: I used isort to order imports, so bulk of changes is cosmetics.