### PR TITLE
update house-energy Windows docker base image

### DIFF
--- a/Python/samples/house-energy/Dockerfile-windows
+++ b/Python/samples/house-energy/Dockerfile-windows
@@ -1,4 +1,4 @@
-FROM python:3.7.3-windowsservercore-1809
+FROM python:3.9.10-windowsservercore-1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]


### PR DESCRIPTION
(Repeating previous commit that I reverted because I accidentally pushed it directly to main instead of to my PR branch.)

I was receiving availability errors from ACI when trying to start training. python:3.7.3-windowsservercore-1809 is no longer listed at https://hub.docker.com/_/python.

Although mcr.microsoft.com/windows/servercore:1809 does seem to have availability, my theory is that an update has occured that has not been incorporated into the python:3.7.3-windowsservercore-1809.

python:3.9.10-windowsservercore-1809 is listed at https://hub.docker.com/_/python and it seems to work, so I'm bumping the version number.